### PR TITLE
upgrade pyyaml to 6.0.1

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -11,7 +11,7 @@ opentype-feature-freezer==1.32.2
 skia-pathops==0.7.4
 
 # to parse YAML config file
-pyyaml==5.4.1
+pyyaml==6.0.1
 
 # to autohint output fonts
 ttfautohint-py>=0.5.0


### PR DESCRIPTION
# Background

Received AttributeError: cython_sources error which I traced to an old version of pyyaml.

<img width="1339" alt="screenshot_20231017_000018@2x" src="https://github.com/kaushikgopal/recursive-code-config/assets/1042037/3ccebf99-9738-4351-b7a7-e415268d7c05">

# Solution

upgrade pyyaml

